### PR TITLE
fix REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,2 +1,2 @@
-julia 0.4-
+julia 0.3 julia 0.4-
 


### PR DESCRIPTION
Since this package exists to support v0.3 Julia, it should have a floor of `julia 0.3` and a ceiling of the first release of v0.4-dev (`julia 0.4-`)