### PR TITLE
Propogate missings with arithmatic

### DIFF
--- a/src/dates/arithmetic.jl
+++ b/src/dates/arithmetic.jl
@@ -75,6 +75,8 @@ end
 (.+){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .+ y
 (.-){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .- y
 
-# Propogatinc missings 
+# Propogate missings 
 +(t::TimeType, m::Missing) = missing
++(m::Missing, t::TimeType) = missing
 -(t::TimeType, m::Missing) = missing
+-(m::Missing, t::TimeType) = missing

--- a/src/dates/arithmetic.jl
+++ b/src/dates/arithmetic.jl
@@ -74,3 +74,7 @@ end
 (.-){T<:TimeType}(x::AbstractArray{T}, y::Period) = reshape(T[i - y for i in x], size(x))
 (.+){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .+ y
 (.-){T<:TimeType}(y::Period, x::AbstractArray{T}) = x .- y
+
+# Propogatinc missings 
++(t::TimeType, m::Missing) = missing
+-(t::TimeType, m::Missing) = missing


### PR DESCRIPTION
This issue: https://github.com/JuliaLang/julia/issues/28570 points out that arithmetic with dates and missing values throws an error. Instead, dates should behave like numbers in this instance, propagating missing values. 

This PR adds 4 methods for operations with missing and `TimeType`. `+`, `-`, and both orders for each. 

However it is likely this adds *too much* behavior, as it seems not all `TimeType` subtypes support `+` (you can't add years).  I would appreciate some guidance for more specific methods to add. 


